### PR TITLE
pipe commands not working correctly when typed in multiple times

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyongsi@student.42.fr>           +#+  +:+       +#+        */
+/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 13:39:49 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/05/29 18:22:11 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/05/30 16:43:50 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,7 +83,9 @@ typedef struct s_shell
 	char	**env;
 	char	*prompt;
 	t_token	*cmd_list;
-	int		heredoc_fd;
+	int		input_fd;
+	int		output_fd;
+	//int		heredoc_fd;
 	int		prev_fd;
 	pid_t	process_ids[100];
 	int		process_count;
@@ -159,6 +161,7 @@ int	num_of_commands(t_shell *minishell);
 int	num_of_pipes(t_shell *minishell);
 int	handle_redirection(t_shell *minishell, t_token *curr);
 void	pipex(t_shell *minishell);
+void	restore_fds(int	input_fd, int output_fd);
 
 // tokenizer
 void	token_add_back(t_token **head, char *token, t_token_type type);
@@ -200,6 +203,7 @@ t_shell	*init_shell(void);
 void free_shell(t_shell *minishell);
 void	initialize_shell(t_shell **minishell, char **envp);
 void	cleanup(t_shell *g_shell);
+void reset_process_ids(t_shell *minishell);
 
 //main.c
 char	*read_input_line(t_shell *g_shell);

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyongsi@student.42.fr>           +#+  +:+       +#+        */
+/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 13:37:14 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/05/26 10:27:52 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/05/30 16:44:52 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,6 +51,8 @@ void	process_command_line(t_shell *minishell, char *line)
 	pipex(minishell);
 	free_tokenlst(token_lst);
 	token_lst = NULL;
+	minishell->prev_fd = -1;
+	reset_process_ids(minishell);
 }
 
 void	main_loop(t_shell *g_shell)

--- a/src/pipex/pipex.c
+++ b/src/pipex/pipex.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipex.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyongsi@student.42.fr>           +#+  +:+       +#+        */
+/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 16:15:14 by axlee             #+#    #+#             */
-/*   Updated: 2024/05/29 18:59:50 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/05/30 16:44:25 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,8 +53,8 @@ int	handle_redirection(t_shell *minishell, t_token *curr)
 	{
 		if (redirect_input(minishell, curr->next->next) != -1)
 		{
-			dup2(minishell->heredoc_fd, STDIN_FILENO);
-			close(minishell->heredoc_fd);
+			dup2(minishell->input_fd, STDIN_FILENO);
+			close(minishell->input_fd);
 			return (1);
 		}
 	}
@@ -63,8 +63,8 @@ int	handle_redirection(t_shell *minishell, t_token *curr)
 	{
 		if (redirect_output(minishell, curr->next->next) != -1)
 		{
-			dup2(minishell->heredoc_fd, STDOUT_FILENO);
-			close(minishell->heredoc_fd);
+			dup2(minishell->output_fd, STDOUT_FILENO);
+			close(minishell->output_fd);
 			return (1);
 		}
 	}
@@ -130,6 +130,20 @@ static void	execute_builtins_or_exc(int	i, t_token *curr, t_shell *minishell)
 		execute_command(i, curr, minishell);
 }
 
+void	restore_fds(int	input_fd, int output_fd)
+{
+	if (output_fd != STDOUT_FILENO)
+	{
+		dup2(output_fd, STDOUT_FILENO);
+		close(output_fd);
+	}
+	if (input_fd != STDIN_FILENO)
+	{
+		dup2(input_fd, STDIN_FILENO);
+		close(input_fd);
+	}
+}
+
 void	pipex(t_shell *minishell)
 {
 	int		i;
@@ -150,6 +164,7 @@ void	pipex(t_shell *minishell)
 		curr = curr->next;
 	}
 	wait_for_all_commands(minishell);
+	restore_fds(minishell->input_fd, minishell->output_fd);
 }
 // need to rewrite pipex
 /**
@@ -162,5 +177,3 @@ in echo i need to move the linked list till its a different type;
 1. check if there is execute_builtins
 2. echo Hello world > output.txt
 **/
-
-

--- a/src/redirect.c
+++ b/src/redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirect.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyongsi@student.42.fr>           +#+  +:+       +#+        */
+/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/18 07:48:39 by axlee             #+#    #+#             */
-/*   Updated: 2024/05/29 18:40:26 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/05/30 17:27:39 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,7 @@ int	redirect_input(t_shell *minishell, t_token *curr)
 		fd = here_doc(minishell, curr->token);
 	}
 	if (fd > 0)
-		minishell->heredoc_fd = fd;
+		minishell->input_fd = fd;
 	return (fd);
 }
 
@@ -90,6 +90,6 @@ int	redirect_output(t_shell *minishell, t_token *curr)
 	printf("type: %d\n", curr->prev->type);
 	fd = open_output(curr->token, curr->prev->type);
 	if (fd > 0)
-		minishell->heredoc_fd = fd;
+		minishell->output_fd = fd;
 	return (fd);
 }

--- a/src/redirect_heredoc.c
+++ b/src/redirect_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 21:03:37 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/05/18 08:42:47 by axlee            ###   ########.fr       */
+/*   Updated: 2024/05/30 16:54:56 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,9 +51,9 @@ static void	here_doc_read(t_shell *minishell, int *pipe_fds, char *delimiter)
 		}
 		if (!ft_strncmp(str, delimiter, delimiter_len + 1))
 			break ;
+		write(pipe_fds[1], str, ft_strlen(str));
+		write(pipe_fds[1], "\n", 1);
 	}
-	write(pipe_fds[1], str, ft_strlen(str));
-	write(pipe_fds[1], "\n", 1);
 	free(str);
 	close(pipe_fds[1]);
 	free_and_exit(minishell, 0);
@@ -80,10 +80,10 @@ int	here_doc(t_shell *minishell, char *delimiter)
 	if (WEXITSTATUS(status) == 130)
 	{
 		close(pipe_des[0]);
-		close(pipe_des[0]);
+		close(pipe_des[1]);
 		return (-1);
 	}
 	close(pipe_des[1]);
-	minishell->heredoc_fd = pipe_des[0];
+	minishell->input_fd = pipe_des[0];
 	return (0);
 }

--- a/src/shell.c
+++ b/src/shell.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   shell.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyongsi@student.42.fr>           +#+  +:+       +#+        */
+/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 13:37:14 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/05/24 16:12:25 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/05/30 16:28:07 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,12 +26,28 @@ t_shell	*init_shell(void)
 	shell->prompt = PROMPT;
 	shell->cmd_list = NULL;
 	shell->last_return = 0;
+	shell->input_fd = dup(STDIN_FILENO);
+	shell->output_fd = dup(STDOUT_FILENO);
 	shell->prev_fd = -1;
 	shell->end = false;
 	return (shell);
 }
 
-void free_shell(t_shell *minishell)
+void reset_process_ids(t_shell *minishell)
+{
+	int	i;
+
+	i = 0;
+
+	while (i < 100)
+	{
+		minishell->process_ids[i] = 0;
+		i++;
+	}
+	minishell->process_count = 0;
+}
+
+void	free_shell(t_shell *minishell)
 {
 	if (minishell == NULL)
 		return;


### PR DESCRIPTION
1. Previous version, entering ls | wc -l twice in a row will result in it waiting for user input.
2. Restored fd back to stdin and stdout.
3. Free the process ids and reset prev_fd to -1 after command is executed.
4. Replaced heredoc_fd with input_fd and output_fd.