### PR TITLE
Fix for exit

### DIFF
--- a/src/execute_commands.c
+++ b/src/execute_commands.c
@@ -6,7 +6,7 @@
 /*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 14:09:33 by axlee             #+#    #+#             */
-/*   Updated: 2024/06/02 13:09:29 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/02 21:06:57 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,8 @@ int	execute_builtin_1(t_token *curr, t_shell *minishell)
 {
 	if (ft_strncmp(curr->token, "cd", 2) == 0)
 	{
-		return (minishell_cd(minishell), 1);
+		minishell_cd(minishell);
+		return (1);
 	}
 	if (ft_strncmp(curr->token, "echo", 4) == 0)
 	{
@@ -74,17 +75,19 @@ int execute_builtin_2(t_token *curr, t_shell *minishell)
 	int	count;
 
 	count = count_tokens(minishell);
-    if (ft_strncmp(curr->token, "exit", 4) == 0)
-    {
-        if (count > 2)
-        {
-            minishell_error_msg("exit", 43);
-            return 1;
-        }
-        minishell_exit(minishell);
-        return 1;
-    }
-    return (0);
+	if (ft_strncmp(curr->token, "exit", 4) == 0)
+	{
+		//printf("in minishell exit\n");
+		//printf("count: %d\n", count);
+		if (count > 2)
+		{
+			minishell_error_msg("exit", 43);
+			return (1);
+		}
+		minishell_exit(minishell);
+		return (1);
+	}
+	return (0);
 }
 
 int	other_cmds(t_token *curr, t_shell *minishell)

--- a/src/pipex/pipex.c
+++ b/src/pipex/pipex.c
@@ -6,7 +6,7 @@
 /*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 16:15:14 by axlee             #+#    #+#             */
-/*   Updated: 2024/06/02 13:17:37 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/02 21:06:00 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,6 +63,8 @@ void execute_builtin_or_exec(t_token *curr, t_shell *minishell)
 	int builtin_type ;
 
 	builtin_type = check_builtin(curr->token);
+	//printf("builtin type: %d\n", builtin_type);
+	//printf("curr type in builtin: %s\n", curr->token);
 	if (builtin_type == 1)
 	{
 		execute_builtin_1(curr, minishell);
@@ -82,6 +84,7 @@ t_token	*handle_echo(t_token *curr, t_shell *minishell)
 	num = num_of_arguments(minishell);
 	index = check_for_redirections(minishell);
 	num_of_pipe = num_of_pipes(minishell);
+	//printf("in handle echo args: %d\n", num);
 	if (num_of_pipe == 0 && (index == 0))
 	{
 		execute_builtin_or_exec(curr, minishell);
@@ -106,7 +109,7 @@ void	pipex(t_shell *minishell)
 			execute_builtin_or_exec(curr, minishell);
 		if ((curr->type == T_IDENTIFIER) && (curr->next) && (curr->next->type == T_PIPE))
 			execute_pipeline(curr, minishell);
-		if (curr->type == T_IDENTIFIER && !ft_strncmp(curr->token, "echo", 4))
+		if (curr->type == T_IDENTIFIER && (check_builtin(curr->token) == 1))
 		{
 			curr = handle_echo(curr, minishell);
 		}


### PR DESCRIPTION
1. exit 42 hi will result in minishell: exit: too many arguments
2. cd src will move to src folder