### PR TITLE
Double Quoted Strings now prints out the variables while Single Quote treats it as literal string.

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyongsi@student.42.fr>           +#+  +:+       +#+        */
+/*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 13:39:49 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/03 13:37:10 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/04 04:22:06 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,6 +59,7 @@ typedef struct s_token
 	t_token_type	type;
 	struct s_token	*next;
 	struct s_token	*prev;
+	int	is_single_quoted;
 }	t_token;
 
 // Struct for commands
@@ -200,7 +201,8 @@ void	handle_env_variable(t_token *curr, t_shell *minishell);
 void	parse_value(t_token *token_lst, t_shell *minishell);
 void	set_token_pointers(t_token *tokens);
 void	handle_cd_command(t_token **curr, t_shell *minishell);
-void	parse_quotes(t_token *token);
+void 	parse_single_quotes(t_token *token);
+void 	parse_double_quotes(t_token *token);
 void	parse_token(t_token *token, t_shell *minishell);
 void	join_identifier_tokens(t_token *lst);
 t_token	*token_parser(t_token *token_lst, t_shell *minishell);

--- a/src/builtins/builtin_echo.c
+++ b/src/builtins/builtin_echo.c
@@ -3,35 +3,22 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_echo.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyongsi@student.42.fr>           +#+  +:+       +#+        */
+/*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/12 09:53:07 by axlee             #+#    #+#             */
-/*   Updated: 2024/06/03 12:14:19 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/04 04:36:05 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void minishell_echo(t_shell *minishell)
+static void print_tokens(t_token *current_token, t_shell *minishell, int newline)
 {
-    int newline = 1;  // Default is to print newline at the end
-
-    if (minishell->cmd_list == NULL)
-        return;
-
-    t_token *current_token = minishell->cmd_list->next; // Skip the 'echo' command itself
-
-    // Check for '-n' option which suppresses the newline
-    if (current_token != NULL && strcmp(current_token->token, "-n") == 0) {
-        newline = 0;  // Do not print newline at the end
-        current_token = current_token->next;  // Move to the next token
-    }
-
     while (current_token != NULL)
     {
         if (current_token->type == T_IDENTIFIER)
         {
-            parse_quotes(current_token); // Parse quotes for each token
+            parse_token(current_token, minishell); // Parse the token
             printf("%s", current_token->token);
             if (current_token->next)
                 printf(" ");  // Add space between arguments
@@ -42,6 +29,23 @@ void minishell_echo(t_shell *minishell)
     }
     if (newline)
         printf("\n");
+}
+
+void minishell_echo(t_shell *minishell)
+{
+    int newline;
+    t_token *current_token;
+
+    newline = 1;  // Default is to print newline at the end
+    if (minishell->cmd_list == NULL)
+        return;
+    current_token = minishell->cmd_list->next; // Skip the 'echo' command itself
+    // Check for '-n' option which suppresses the newline
+    if (current_token != NULL && strcmp(current_token->token, "-n") == 0) {
+        newline = 0;  // Do not print newline at the end
+        current_token = current_token->next;  // Move to the next token
+    }
+    print_tokens(current_token, minishell, newline);
 }
 
 // Test cases that failed
@@ -72,13 +76,10 @@ void minishell_echo(t_shell *minishell)
 // echo "\$TEST"
 // Output: \$TEST
 // Correct Output: $TEST
-// echo "$=TEST"
+// echo "$="
 // Output:
-// Correct Output: $=TEST
-// echo "$"
-// Output:
-// Correct Output: $
-// echo "$?TEST"
+// Correct Output: $=
+// echo "$?"
 // Output:
 // Correct Output: 0TEST
 // echo "$1TEST"

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 13:35:24 by axlee             #+#    #+#             */
-/*   Updated: 2024/05/30 20:15:42 by axlee            ###   ########.fr       */
+/*   Updated: 2024/06/04 04:18:04 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,12 +59,24 @@ void	set_token_pointers(t_token *tokens)
 
 void parse_token(t_token *token, t_shell *minishell)
 {
-	if (strcmp(token->token, "echo") == 0 && token->next)
-        parse_quotes(token->next);  // Apply quote parsing to the argument of echo
+    char *str;
+    int len;
+
+    str = token->token;
+    len = ft_strlen(str);
+    if (len > 1 && str[0] == '\"' && str[len - 1] == '\"')
+        parse_double_quotes(token); // Parse double quotes
+    else if (len > 1 && str[0] == '\'' && str[len - 1] == '\'')
+        parse_single_quotes(token); // Parse single quotes
+    if (!token->is_single_quoted)
+	{
+        if (strchr(token->token, '$'))
+        {
+            parse_value(token, minishell);
+        }
+    }
     if (strchr(token->token, ';'))
         parse_semicolon(token);
-    if (strchr(token->token, '$'))
-        parse_value(token, minishell);
 }
 
 t_token	*token_parser(t_token *token_lst, t_shell *minishell)

--- a/src/parser/parser_commands.c
+++ b/src/parser/parser_commands.c
@@ -6,7 +6,7 @@
 /*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/26 16:54:35 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/05/31 15:12:52 by axlee            ###   ########.fr       */
+/*   Updated: 2024/06/04 02:42:01 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -135,6 +135,7 @@ void	parse_value(t_token *token_lst, t_shell *minishell)
 	t_token	*curr;
 	char	*token;
 	char	*exit_status_str;
+    char    *new_token;
 	int		exit_status;
 
 	curr = token_lst;
@@ -148,8 +149,10 @@ void	parse_value(t_token *token_lst, t_shell *minishell)
 	{
 		exit_status = minishell->last_return ;
 		exit_status_str = ft_itoa(exit_status);
+        new_token = ft_strjoin(exit_status_str, token + 2);
 		free(curr->token);
-		curr->token = exit_status_str;
+		curr->token = new_token;
+        free(exit_status_str);
 	}
 	else
 		handle_env_variable(curr, minishell);

--- a/src/parser/parser_commands.c
+++ b/src/parser/parser_commands.c
@@ -6,94 +6,60 @@
 /*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/26 16:54:35 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/04 02:42:01 by axlee            ###   ########.fr       */
+/*   Updated: 2024/06/04 04:38:05 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-/*void parse_singlequote(t_token *t)
+void parse_single_quotes(t_token *token)
 {
-    char *result;
     char *str;
-    int i;
-    int j;
+    int len;
+    char *result;
 
-    i = 0;
-    j = 0;
-    str = t->token;
-    result = (char *)malloc(strlen(str) + 1);
+    str = token->token;
+    len = ft_strlen(str);
+    result = malloc(len - 1); // Allocate memory for the string without quotes
     if (!result)
         return;
-
-    while (str[i] != '\0') {
-        if (str[i] == '\'') {
-            i++;  // Skip the opening single quote
-            while (str[i] != '\'' && str[i] != '\0') {
-                result[j++] = str[i++];  // Copy everything inside the single quotes
-            }
-            if (str[i] == '\'') {
-                i++;  // Skip the closing single quote
-            }
-        } else {
-            result[j++] = str[i++];
-        }
+    if (len > 1 && str[0] == '\'' && str[len - 1] == '\'')
+    {
+        ft_memcpy(result, str + 1, len - 2); // Copy the string without the quotes
+        result[len - 2] = '\0';
+        token->is_single_quoted = 1;
     }
-    result[j] = '\0';
-    free(t->token);
-    t->token = result;
-}*/
+    else 
+    {
+        ft_strcpy(result, str);
+        token->is_single_quoted = 0;
+    }
+    free(token->token);
+    token->token = result;
+}
 
-
-/*void parse_doublequote(t_token *t)
+void parse_double_quotes(t_token *token)
 {
-    char *result;
     char *str;
-    int i;
-    int j;
+    int len;
+    char *result;
 
-    i = 0;
-    j = 0;
-    str = t->token;
-    result = (char *)malloc(strlen(str) + 1);
+    str = token->token;
+    len = ft_strlen(str);
+    result = malloc(len - 1); // Allocate memory for the string without quotes
     if (!result)
         return;
-
-    while (str[i] != '\0') {
-        if (str[i] == '\"') {
-            i++;  // Skip the opening single quote
-            while (str[i] != '\"' && str[i] != '\0') {
-                result[j++] = str[i++];  // Copy everything inside the single quotes
-            }
-            if (str[i] == '\"') {
-                i++;  // Skip the closing single quote
-            }
-        } else {
-            result[j++] = str[i++];
-        }
+    if (len > 1 && str[0] == '\"' && str[len - 1] == '\"')
+    {
+        ft_memcpy(result, str + 1, len - 2); // Copy the string without the quotes
+        result[len - 2] = '\0';
+        token->is_single_quoted = 0;
     }
-    result[j] = '\0';
-    free(t->token);
-    t->token = result;
-}*/
-
-void parse_quotes(t_token *token)
-{
-    char *str = token->token;
-    int len = strlen(str);
-    char *result = malloc(len + 1); // Allocate space for the new string
-    if (!result) return; // Always check malloc return
-
-    // Check if the entire token is encapsulated by single or double quotes
-    if (len > 1 && ((str[0] == '\'' && str[len - 1] == '\'') || (str[0] == '\"' && str[len - 1] == '\"'))) {
-        // Copy the inside, excluding the outermost quotes
-        memcpy(result, str + 1, len - 2);
-        result[len - 2] = '\0'; // Null-terminate the new string
-    } else {
-        // If not encapsulated by quotes, just copy the string
-        strcpy(result, str);
+    else 
+    {
+        ft_strcpy(result, str);
+        token->is_single_quoted = 0;
     }
-
     free(token->token);
     token->token = result;
 }
@@ -125,7 +91,7 @@ void	handle_env_variable(t_token *curr, t_shell *minishell)
 	env_value = get_env_value(minishell, result);
 	free(result);
 	if (!env_value)
-		env_value = (" ");
+		env_value = ft_strdup(" ");
 	free(curr->token);
 	curr->token = env_value;
 }
@@ -141,10 +107,18 @@ void	parse_value(t_token *token_lst, t_shell *minishell)
 	curr = token_lst;
 	token = curr->token;
 	exit_status = 0;
+	new_token = NULL;
 	if (token == NULL || token[0] != '$')
 		return ;
 	if (ft_strcmp(token, "$") == 0)
 		return ;
+	else if (ft_strcmp(token, "$?") == 0)
+	{
+		exit_status = minishell->last_return ;
+		exit_status_str = ft_itoa(exit_status);
+		free(curr->token);
+		curr->token = new_token;
+	}
 	else if (ft_strncmp(token, "$?", 2) == 0)
 	{
 		exit_status = minishell->last_return ;
@@ -157,4 +131,3 @@ void	parse_value(t_token *token_lst, t_shell *minishell)
 	else
 		handle_env_variable(curr, minishell);
 }
-

--- a/src/tokenizer/tokenizer.c
+++ b/src/tokenizer/tokenizer.c
@@ -207,6 +207,45 @@ void handle_backslash(char **line, t_token **token_lst)
 
 void handle_quotes(char **line, t_token **token_lst)
 {
+    char quote_type;
+    char *start;
+    int length;
+    char *quoted_content;
+    char *literal_quote;
+
+    quote_type = **line;
+    start = *line; // Include the opening quote
+    (*line)++; // Move past the opening quote
+    while (**line && **line != quote_type) // Find the closing quote
+        (*line)++;
+    if (**line == quote_type)
+    {
+        (*line)++; // Move past the closing quote
+        length = *line - start;
+        quoted_content = (char *)malloc(length + 1);
+        if (quoted_content)
+        {
+            strncpy(quoted_content, start, length);
+            quoted_content[length] = '\0';
+            token_add_back(token_lst, quoted_content, T_IDENTIFIER);
+            free(quoted_content);
+        }
+    }
+    else
+    {
+        // If no closing quote is found, treat the opening quote as a literal character
+        literal_quote = (char *)malloc(2);
+        if (literal_quote) {
+            literal_quote[0] = quote_type;
+            literal_quote[1] = '\0';
+            token_add_back(token_lst, literal_quote, T_IDENTIFIER);
+            free(literal_quote);
+        }
+    }
+}
+
+/*void handle_quotes(char **line, t_token **token_lst)
+{
     char quote_type = **line;
     (*line)++; // Move past the opening quote
     char *start = *line;
@@ -232,7 +271,7 @@ void handle_quotes(char **line, t_token **token_lst)
             free(literal_quote);
         }
     }
-}
+}*/
 
 t_token *token_processor(char *line, t_shell *minishell)
 {


### PR DESCRIPTION
![image](https://github.com/gysiang/minishell/assets/124663345/d87b9eb7-6d97-4f16-b28d-f2b3dbf42231)

Now the command execution is properly going through in gdb -tui ./minishell instead of bypassing it. 

Need to resolve $? as I broke it after editing this portion. Will work on it later.
