### PR TITLE
resolved new line when cat is interrupted

### DIFF
--- a/src/pipex/execute.c
+++ b/src/pipex/execute.c
@@ -6,7 +6,7 @@
 /*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/24 14:59:21 by axlee             #+#    #+#             */
-/*   Updated: 2024/06/06 11:12:10 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/06 23:43:56 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,14 +17,21 @@ void	execute_single_command(t_token *curr, t_shell *minishell)
 	int	pid;
 
 	pid = fork();
+	if (!ft_strcmp(curr->token, "./minishell"))
+		g_signal_received = 1;
 	if (pid == 0)
 	{
+		signal(SIGINT, SIG_DFL);
 		load_previous_fd(minishell);
 		exec_cmd(curr, minishell);
 	}
 	else
 	{
-		signal(SIGINT, SIG_IGN);
+		//printf("g_signal: %d\n", g_signal_received);
+		if (g_signal_received == 1)
+			signal(SIGINT, SIG_IGN);
+		else
+			signal(SIGINT, sigint_handler1);
 		minishell->process_ids[minishell->process_count++] = pid;
 		if (minishell->prev_fd != -1)
 			close(minishell->prev_fd);

--- a/src/pipex/execute_utils.c
+++ b/src/pipex/execute_utils.c
@@ -6,7 +6,7 @@
 /*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/06 10:21:39 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/06 11:18:42 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/06 23:23:11 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,14 +19,14 @@ int	check_command(char *cmd, t_shell *minishell)
 		printf("Invalid command or shell context\n");
 		ft_putstr_fd("Not enough arguments to exec_cmd\n", STDERR_FILENO);
 		minishell->last_return = 1;
-		return (1);
+		exit(1);
 	}
 	if (ft_strncmp(cmd, "$?", 2) == 0)
 	{
 		printf("Handling special case for last return status\n");
 		printf("%d\n", minishell->last_return);
 		minishell->last_return = 0;
-		return (1);
+		exit(1);
 	}
 	return (0);
 }
@@ -84,7 +84,6 @@ void	exec_cmd(t_token *curr, t_shell *minishell)
 	check_command(curr->token, minishell);
 	s_cmd = get_command_array(curr->token, minishell);
 	path = get_command_path(s_cmd, minishell);
-	signal(SIGINT, sigint_handler1);
 	if (execve(path, s_cmd, minishell->env) == -1)
 	{
 		printf("execve failed: %s\n", strerror(errno));

--- a/src/pipex/pipex.c
+++ b/src/pipex/pipex.c
@@ -6,7 +6,7 @@
 /*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 16:15:14 by axlee             #+#    #+#             */
-/*   Updated: 2024/06/06 10:37:43 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/06 23:08:30 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,8 +55,8 @@ static void	wait_for_all_commands(t_shell *minishell)
 			minishell->last_return = 1;
 		i++;
 	}
-	minishell->process_count = 0;
 	signal(SIGINT, sigint_handler);
+	minishell->process_count = 0;
 }
 
 t_token	*handle_builtins(t_token *curr, t_shell *minishell)

--- a/src/signals.c
+++ b/src/signals.c
@@ -6,7 +6,7 @@
 /*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/11 19:33:11 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/06 01:14:59 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/06 22:52:43 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ void	sigint_handler1(int signal)
 {
 	(void)signal;
 	g_signal_received = 1;
-	write(1, "signal_int", 10);
+	//write(1, "signal_int", 10);
 	write(1, "\n", 1);
 }
 


### PR DESCRIPTION
1. Using the global variable as switch to adjust when to ignore sigint or print new line in execute_single_command