### PR TITLE
Resolved memory leaks when incorrect commands are issued

### DIFF
--- a/src/env_manager_utils.c
+++ b/src/env_manager_utils.c
@@ -6,17 +6,20 @@
 /*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 14:09:33 by axlee             #+#    #+#             */
-/*   Updated: 2024/06/14 12:58:58 by axlee            ###   ########.fr       */
+/*   Updated: 2024/06/14 15:33:31 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 // If return (strdup == "", it will output echo $TEST as empty string but further issues at the back)
-char	*get_env_value(t_shell *minishell, const char *var)
+/*char	*get_env_value(t_shell *minishell, const char *var)
 {
 	int		i;
 	size_t	var_len;
+	int		i;
+	size_t	var_len;
+	char	*value;
 
 	var_len = ft_strlen(var);
 	i = 0;
@@ -31,6 +34,33 @@ char	*get_env_value(t_shell *minishell, const char *var)
 	}
 	// Return an empty string if the environment variable is not found
 	return (ft_strdup(""));
+}*/
+
+char	*get_env_value(t_shell *minishell, const char *var)
+{
+	int		i;
+	size_t	var_len;
+	char	*value;
+
+	value = NULL;
+	var_len = ft_strlen(var);
+	i = 0;
+	while (minishell->env[i])
+	{
+		if (ft_strncmp(minishell->env[i], var, var_len) == 0
+			&& minishell->env[i][var_len] == '=')
+		{
+			value = ft_strdup(&minishell->env[i][var_len + 1]);
+			if (value == NULL)
+			{
+				// Handle memory allocation failure
+				return (NULL);
+			}
+			return (value);
+		}
+		i++;
+	}
+	return (NULL);
 }
 
 // If return NULL, it will output echo $ as $ but will also output echo $TEST as $TEST
@@ -38,6 +68,7 @@ char	*get_env_value(t_shell *minishell, const char *var)
 {
 	int		i;
 	size_t	var_len;
+	int		i;
 
 	var_len = ft_strlen(var);
 	i = 0;
@@ -50,10 +81,9 @@ char	*get_env_value(t_shell *minishell, const char *var)
 	}
 	return (NULL);
 }*/
-
 int	env_len(t_shell *minishell)
 {
-	int	i;
+	int		i;
 
 	i = 0;
 	while (minishell->env[i])

--- a/src/parser/parse_value.c
+++ b/src/parser/parse_value.c
@@ -6,7 +6,7 @@
 /*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/26 16:54:35 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/14 12:57:43 by axlee            ###   ########.fr       */
+/*   Updated: 2024/06/14 14:09:45 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ void	handle_env_variable(t_token *curr, t_shell *minishell)
 	result[0] = '\0';
 
 	// Skip the '$' character
-	//token++;
+	token++;
 
 	// Extract the variable name
 	var_name = ft_strdup(token);

--- a/src/pipex/execute_utils.c
+++ b/src/pipex/execute_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execute_utils.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
+/*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/06 10:21:39 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/14 00:51:14 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/14 15:09:25 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,5 +80,6 @@ void	exec_cmd(t_token *curr, t_shell *minishell)
 		return_code = minishell_error_msg(s_cmd[0], errno);
 		minishell->last_return = return_code;
 	}
+	free(path);
 	ft_free_tab(s_cmd);
 }

--- a/src/pipex/pipex_utils.c
+++ b/src/pipex/pipex_utils.c
@@ -6,7 +6,7 @@
 /*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/12 10:23:30 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/10 22:07:44 by axlee            ###   ########.fr       */
+/*   Updated: 2024/06/14 15:25:44 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,81 @@ void	ft_free_tab(char **tab)
 	free(tab);
 }
 
+//OPTION_1
+/*static char	*try_exec_path(char **all_path, char **s_cmd)
+{
+	int		i;
+	char	*exec;
+	char	*path_part;
+
+	i = 0;
+	while (all_path[i])
+	{
+		path_part = ft_strjoin(all_path[i], "/");
+		exec = ft_strjoin(path_part, s_cmd[0]);
+		free(path_part);
+		if (access(exec, F_OK | X_OK) == 0)
+		{
+			return (exec);
+		}
+		free(exec);
+		i++;
+	}
+	return (NULL);
+}
+
 char	*get_path(char *cmd, t_shell *minishell)
+{
+	char	*exec;
+	char	**all_path;
+	char	**s_cmd;
+	char	*env_path;
+
+	env_path = get_env_value(minishell, "PATH");  // Use custom get_env_value
+	if (env_path == NULL)
+		return (NULL);
+	all_path = ft_split(env_path, ':');
+	free(env_path);  // Free the memory allocated by get_env_value
+	s_cmd = ft_split(cmd, ' ');
+	exec = try_exec_path(all_path, s_cmd);
+	ft_free_tab(all_path);
+	ft_free_tab(s_cmd);
+	return (exec);
+}*/
+
+//OPTION_2 (PREFFERED)
+char	*get_path(char *cmd, t_shell *minishell)
+{
+	int		i;
+	char	*exec;
+	char	*path_part;
+	char	**all_path;
+	char	**s_cmd;
+
+	(void)minishell;
+	i = -1;
+	all_path = ft_split(getenv("PATH"), ':');
+	s_cmd = ft_split(cmd, ' ');
+	while (all_path[++i])
+	{
+		path_part = ft_strjoin(all_path[i], "/");
+		exec = ft_strjoin(path_part, s_cmd[0]);
+		free(path_part);
+		if (access(exec, F_OK | X_OK) == 0)
+		{
+			ft_free_tab(s_cmd);
+			ft_free_tab(all_path);
+			return (exec);
+		}
+		free(exec);
+	}
+	ft_free_tab(all_path);
+	ft_free_tab(s_cmd);
+	return (NULL);
+}
+
+//OPTION_3
+/*char	*get_path(char *cmd, t_shell *minishell)
 {
 	int		i;
 	char	*exec;
@@ -72,7 +146,7 @@ char	*get_path(char *cmd, t_shell *minishell)
 	ft_free_tab(all_path);
 	ft_free_tab(s_cmd);
 	return (NULL);
-}
+}*/
 
 void	restore_fds(int input_fd, int output_fd)
 {

--- a/src/shell.c
+++ b/src/shell.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   shell.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
+/*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 13:37:14 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/11 21:17:57 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/14 15:30:49 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,5 +78,6 @@ void	initialize_shell(t_shell **minishell, char **envp)
 void	cleanup(t_shell *g_shell)
 {
 	free_shell(g_shell);
-	clear_history();
+	rl_clear_history();
+	//clear_history();
 }

--- a/src/sutils_2.c
+++ b/src/sutils_2.c
@@ -13,14 +13,59 @@
 
 #include "minishell.h"
 
-static size_t	ft_get_size(void *ptr)
+size_t	ft_get_size(char **array)
 {
+	size_t	size;
+
+	size = 0;
+	if (array == NULL)
+		return (0);
+	while (array[size] != NULL)
+		size++;
+	return (size);
+}
+
+/*static size_t	ft_get_size(void *ptr)
+{
+	void	*new_ptr;
+	size_t	old_size;
+	void	*new_ptr;
+	size_t	old_size;
+	void	*new_ptr;
+	size_t	old_size;
+	size_t	min_size;
+
 	if (ptr == NULL)
 		return (0);
 	return (*((size_t *)ptr - 1));
+}*/
+void	*ft_realloc(void *ptr, size_t new_size)
+{
+	size_t	old_size;
+	void	*new_ptr;
+	size_t	min_size;
+
+	if (new_size == 0)
+	{
+		free(ptr);
+		return (NULL);
+	}
+	if (ptr == NULL)
+		return (malloc(new_size));
+	old_size = ft_get_size(ptr) * sizeof(char *);
+	new_ptr = malloc(new_size);
+	if (new_ptr == NULL)
+		return (NULL);
+	if (old_size < new_size)
+		min_size = old_size;
+	else
+		min_size = new_size;
+	ft_memcpy(new_ptr, ptr, min_size);
+	free(ptr);
+	return (new_ptr);
 }
 
-void	*ft_realloc(void *ptr, size_t new_size)
+/*void	*ft_realloc(void *ptr, size_t new_size)
 {
 	void	*new_ptr;
 	size_t	old_size;
@@ -42,8 +87,7 @@ void	*ft_realloc(void *ptr, size_t new_size)
 		ft_memcpy(new_ptr, ptr, new_size);
 	free(ptr);
 	return (new_ptr);
-}
-
+}*/
 void	reset_minishell(t_shell *minishell)
 {
 	minishell->prev_fd = -1;
@@ -52,4 +96,3 @@ void	reset_minishell(t_shell *minishell)
 	minishell->signal_received = 0;
 	minishell->flag = 0;
 }
-


### PR DESCRIPTION
![image](https://github.com/gysiang/minishell/assets/124663345/b1afb90b-f8bf-4b6a-a637-80c529d4455b)

Some memory, such as the command history maintained by readline, is intentionally kept until the program exits. This is why Valgrind reports "still reachable" memory blocks. These blocks are not leaks but are still accessible and managed by the readline library.