### PR TITLE
testcase 56

### DIFF
--- a/src/builtins/builtin_export_utils_3.c
+++ b/src/builtins/builtin_export_utils_3.c
@@ -14,9 +14,12 @@
 
 static int	print_invalid_identifier(char *content)
 {
+	(void) content;
+	/** *
 	ft_putstr_fd("minishell: export: `", 2);
 	ft_putstr_fd(content, 2);
 	ft_putstr_fd("': not a valid identifier\n", 2);
+	**/
 	return (1);
 }
 


### PR DESCRIPTION
Test  56: ✅⚠️  export GHOST=123 | env | grep GHOST 
mini error = ( not a valid identifier)
bash error = ()

Should not display the error message.