### PR TITLE
cat <minishell.h|ls

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyongsi@student.42.fr>           +#+  +:+       +#+        */
+/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 13:39:49 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/27 13:00:38 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/28 23:56:02 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -330,6 +330,7 @@ void				restore_fds(int *input_fd, int *output_fd);
 void				safe_close(int *fd);
 
 // pipex
+int					handle_single_redirection(t_shell *minishell, t_token *curr);
 int					handle_redirection(t_shell *minishell, t_token *curr);
 t_token				*handle_builtins(t_token *curr, t_shell *minishell);
 void				pipex(t_shell *minishell);

--- a/src/pipex/execute_4.c
+++ b/src/pipex/execute_4.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   execute_5.c                                        :+:      :+:    :+:   */
+/*   execute_4.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
+/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/26 19:50:26 by axlee             #+#    #+#             */
-/*   Updated: 2024/06/26 19:52:39 by axlee            ###   ########.fr       */
+/*   Updated: 2024/06/28 23:47:45 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,9 @@ void	setup_child_for_redirection(int *pipe_fd, t_shell *minishell)
 	signal(SIGINT, SIG_DFL);
 	signal(SIGPIPE, SIG_IGN);
 	load_previous_fd_to_stdin(minishell);
-	close(pipe_fd[0]);
+	dup2(pipe_fd[1], STDOUT_FILENO);
+	safe_close(&pipe_fd[1]);
+	safe_close(&pipe_fd[0]);
 }
 
 int	handle_child_redirection_process(t_token *curr, int *pipe_fd,
@@ -25,11 +27,12 @@ int	handle_child_redirection_process(t_token *curr, int *pipe_fd,
 {
 	if (handle_redirection(minishell, curr->next) == -1)
 	{
-		close(pipe_fd[1]);
+		safe_close(&pipe_fd[0]);
+		safe_close(&pipe_fd[1]);
 		return (-1);
 	}
 	dup2(pipe_fd[1], STDOUT_FILENO);
-	close(pipe_fd[1]);
+	safe_close(&pipe_fd[1]);
 	return (0);
 }
 
@@ -37,10 +40,10 @@ void	child_process_for_redirection(t_token *curr, int *pipe_fd,
 		t_shell *minishell)
 {
 	setup_child_for_redirection(pipe_fd, minishell);
-	if (handle_child_redirection_process(curr, pipe_fd, minishell) == -1)
-		exit(minishell->last_return);
-	exec_cmd(curr, minishell);
-	exit(minishell->last_return);
+	//if (handle_child_redirection_process(curr, pipe_fd, minishell) == -1)
+	//	exit(minishell->last_return);
+	handle_redirections(curr, minishell);
+	execute_builtin_or_exec_exit(curr, minishell);
 }
 
 void	parent_process_for_redirection(int pid, int *pipe_fd,
@@ -48,7 +51,7 @@ void	parent_process_for_redirection(int pid, int *pipe_fd,
 {
 	handle_redir_parent_process(minishell, pid);
 	minishell->prev_fd = pipe_fd[0];
-	close(pipe_fd[1]);
+	safe_close(&pipe_fd[1]);
 }
 
 void	execute_redirection_with_pipe(t_token *curr, t_shell *minishell)

--- a/src/pipex/execute_5.c
+++ b/src/pipex/execute_5.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execute_5.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
+/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/11 16:10:53 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/06/26 19:57:07 by axlee            ###   ########.fr       */
+/*   Updated: 2024/06/28 23:54:43 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,7 @@ void	handle_redir_child_process(t_token *curr, t_shell *minishell)
 		&& check_redirection_type(curr->next))
 	{
 		minishell->redir_no += 1;
-		handle_redirection(minishell, curr->next);
+		handle_single_redirection(minishell, curr->next);
 		if (curr->next->next != NULL)
 			curr = curr->next->next;
 		else
@@ -65,7 +65,7 @@ t_token	*execute_with_redir(t_token *curr, t_shell *minishell)
 	if (pipe == 0 && num_of_redir <= 3)
 		execute_command_with_redir(curr, minishell);
 	else
-		execute_redirection_with_pipe(curr, minishell);
+		execute_pipeline(curr, minishell);
 	curr = update_curr_pointer(curr, minishell->redir_no, i);
 	return (curr);
 }

--- a/src/pipex/pipex.c
+++ b/src/pipex/pipex.c
@@ -6,13 +6,13 @@
 /*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/17 16:15:14 by axlee             #+#    #+#             */
-/*   Updated: 2024/06/27 10:30:26 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/06/28 23:56:41 by gyong-si         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int	handle_single_redirection(t_shell *minishell, t_token *curr)
+int	handle_single_redirection(t_shell *minishell, t_token *curr)
 {
 	int	result;
 


### PR DESCRIPTION
minishell$ cat <missing.h|ls
minishell: missing.h: No such file or directory
==1797540== Memcheck, a memory error detector
==1797540== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1797540== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==1797540== Command: /usr/bin/ls
==1797540== 
==1797539== 
==1797539== FILE DESCRIPTORS: 3 open (3 std) at exit.
==1797539== 
==1797539== HEAP SUMMARY:
==1797539==     in use at exit: 204,205 bytes in 222 blocks
==1797539==   total heap usage: 514 allocs, 292 frees, 230,223 bytes allocated
==1797539== 
==1797539== LEAK SUMMARY:
==1797539==    definitely lost: 0 bytes in 0 blocks
==1797539==    indirectly lost: 0 bytes in 0 blocks
==1797539==      possibly lost: 0 bytes in 0 blocks
==1797539==    still reachable: 0 bytes in 0 blocks
==1797539==         suppressed: 204,205 bytes in 222 blocks
==1797539== 
==1797539== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
--1797539-- 
--1797539-- used_suppression:     63 leak readline ./readline.supp:2 suppressed: 204,205 bytes in 222 blocks

The rest of leaks are from ls