### PR TITLE
Made tab key unable to execute after 1 press of the key. 2 press however will still trigger readline (nothing we can do about it)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: gyong-si <gyong-si@student.42.fr>          +#+  +:+       +#+        */
+/*   By: axlee <axlee@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/10 13:37:14 by gyong-si          #+#    #+#             */
-/*   Updated: 2024/07/03 12:59:11 by gyong-si         ###   ########.fr       */
+/*   Updated: 2024/07/04 20:17:39 by axlee            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,9 @@ char	*read_input_line(t_shell *g_shell)
 			trimmed_line++;
 		if (*trimmed_line != '\0')
 			return (line);
+		rl_on_new_line();
+		rl_replace_line("", 0);
+		rl_redisplay();
 		free(line);
 	}
 }


### PR DESCRIPTION
@gysiang I had a look at other people minishell including avery's. None of them resolved the tab issue so we will still defend it as usual because it is impossible to close without without bindkey command. 

Our previous problem was that the moment we hit tab, ls comes out. Now if we hit tab and arrow keys consecutively, it will not appear. Hitting tab once will not show ls, but hitting it twice will still show. 